### PR TITLE
Update ignores to skip PyCharm files, zip archives and pdf plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
+# Large graphs
+*.pdf
+
+# PyCharm files
+.idea/
+
 # Archives
 *.tar.gz
+*.zip
 
 # Mac OS
 .DS_Store


### PR DESCRIPTION
Update ignores to skip PyCharm files, zip archives and pdf plots.
